### PR TITLE
Fix nested ternary operators without explicit parentheses issue for P…

### DIFF
--- a/Framework/db/orm/rowcollection.php
+++ b/Framework/db/orm/rowcollection.php
@@ -515,7 +515,7 @@ class ROWCollection implements \Iterator, \ArrayAccess, \SeekableIterator, \Coun
     
     $sqlp = $this->getSQL();
     
-    $sql = 'SELECT '.($count ? 'COUNT(*)' : $sqlp['SELECT']).' FROM '.$sqlp['FROM'].' '.$sqlp['JOIN'].' '.($sqlp['WHERE'] ? 'WHERE '.$sqlp['WHERE'] : '').' '.($count ? '' : isset($sqlp['ORDER']) ? $sqlp['ORDER'] : '').' '.(isset($sqlp['LIMIT']) ? $sqlp['LIMIT'] : '');
+    $sql = 'SELECT '.($count ? 'COUNT(*)' : $sqlp['SELECT']).' FROM '.$sqlp['FROM'].' '.$sqlp['JOIN'].' '.($sqlp['WHERE'] ? 'WHERE '.$sqlp['WHERE'] : '').' '.($count ? '' : (isset($sqlp['ORDER']) ? $sqlp['ORDER'] : '')).' '.(isset($sqlp['LIMIT']) ? $sqlp['LIMIT'] : '');
     
     //echo $sql.PHP_EOL;
     //print_r($params);


### PR DESCRIPTION
Fix nested ternary operators without explicit parentheses issue for PHP7.4:
- Details: https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary
- Error in SportsThread app:
![image](https://user-images.githubusercontent.com/8423992/198541391-c6096dad-b362-4529-99ae-d8c7290d82e0.png)
